### PR TITLE
Ensure ThreadLocal request cleanup after action processing

### DIFF
--- a/src/pss/www/platform/actions/JWebRequest.java
+++ b/src/pss/www/platform/actions/JWebRequest.java
@@ -310,8 +310,11 @@ public class JWebRequest {
 //
 	public synchronized void detachFromRunningThread() throws Exception {
 //		this.setSession(null);
-		JWebApplicationSession.detachGlobals();
-		JWebActionFactory.CURRENT_REQUEST.set(null);
+		try {
+			JWebApplicationSession.detachGlobals();
+		} finally {
+			JWebActionFactory.CURRENT_REQUEST.remove();
+		}
 //		conex--;
 //		PssLogger.logInfo("---------------------------------------------------------------------> conexiones close: "+conex);
 

--- a/src/pss/www/platform/actions/resolvers/JBasicWebActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/JBasicWebActionResolver.java
@@ -158,13 +158,13 @@ public abstract class JBasicWebActionResolver extends AbstractAction implements 
 			this.processAction();
 
 			Map<String, Object> oFinalResultMap=this.getFinalResultMap();
-			this.cleanUp();
 			return oFinalResultMap;
 
 		} catch (Throwable e) {
-			this.cleanUp();
-		  PssLogger.logError(e);
+			PssLogger.logError(e);
 			throw new ProcessingException("Uncaught error while processing action '"+this.getActionName()+"'", e);
+		} finally {
+			this.cleanUp();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Use ThreadLocal#remove when detaching a JWebRequest
- Guarantee request cleanup in JBasicWebActionResolver via finally block

## Testing
- `javac src/pss/www/platform/actions/JWebRequest.java` *(fails: package org.apache.cocoon.environment does not exist)*
- `javac src/pss/www/platform/actions/resolvers/JBasicWebActionResolver.java` *(fails: package javax.servlet.http does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6896bfaeac08833381a16b6a52edb08d