### PR TITLE
Refactor action resolution with strategy pattern

### DIFF
--- a/src/pss/www/platform/actions/resolvers/ActionResolverStrategy.java
+++ b/src/pss/www/platform/actions/resolvers/ActionResolverStrategy.java
@@ -1,0 +1,9 @@
+package pss.www.platform.actions.resolvers;
+
+import pss.core.win.submits.JAct;
+import pss.www.platform.actions.results.JWebActionResult;
+
+public interface ActionResolverStrategy {
+    boolean supports(JDoPssActionResolver context, JAct submit) throws Exception;
+    JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable;
+}

--- a/src/pss/www/platform/actions/resolvers/BackActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/BackActionResolver.java
@@ -1,0 +1,22 @@
+package pss.www.platform.actions.resolvers;
+
+import pss.core.win.submits.JAct;
+import pss.core.win.submits.JActBack;
+import pss.www.platform.actions.results.JWebActionResult;
+
+public class BackActionResolver implements ActionResolverStrategy {
+    @Override
+    public boolean supports(JDoPssActionResolver context, JAct submit) {
+        return submit.getClass().isAssignableFrom(JActBack.class);
+    }
+
+    @Override
+    public JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable {
+        JAct backSubmit = context.getBackAct((JActBack) submit);
+        if (context.hasToSubmit(backSubmit)) {
+            return context.processSubmit(backSubmit);
+        }
+        context.assignTarget(backSubmit);
+        return context.goOn();
+    }
+}

--- a/src/pss/www/platform/actions/resolvers/LinkActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/LinkActionResolver.java
@@ -1,0 +1,17 @@
+package pss.www.platform.actions.resolvers;
+
+import pss.core.win.submits.JAct;
+import pss.core.win.submits.JActExternalLink;
+import pss.www.platform.actions.results.JWebActionResult;
+
+public class LinkActionResolver implements ActionResolverStrategy {
+    @Override
+    public boolean supports(JDoPssActionResolver context, JAct submit) {
+        return submit instanceof JActExternalLink;
+    }
+
+    @Override
+    public JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable {
+        return context.processRedirectLink(submit);
+    }
+}

--- a/src/pss/www/platform/actions/resolvers/QueryActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/QueryActionResolver.java
@@ -1,0 +1,17 @@
+package pss.www.platform.actions.resolvers;
+
+import pss.core.win.submits.JAct;
+import pss.www.platform.actions.results.JWebActionResult;
+
+public class QueryActionResolver implements ActionResolverStrategy {
+    @Override
+    public boolean supports(JDoPssActionResolver context, JAct submit) {
+        return true;
+    }
+
+    @Override
+    public JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable {
+        context.assignTarget(submit);
+        return context.goOn();
+    }
+}

--- a/src/pss/www/platform/actions/resolvers/RedirectActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/RedirectActionResolver.java
@@ -1,0 +1,17 @@
+package pss.www.platform.actions.resolvers;
+
+import pss.core.win.submits.JAct;
+import pss.core.win.submits.JActFileGenerate;
+import pss.www.platform.actions.results.JWebActionResult;
+
+public class RedirectActionResolver implements ActionResolverStrategy {
+    @Override
+    public boolean supports(JDoPssActionResolver context, JAct submit) {
+        return submit.getFinalSubmit() instanceof JActFileGenerate;
+    }
+
+    @Override
+    public JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable {
+        return context.processRedirect(submit);
+    }
+}

--- a/src/pss/www/platform/actions/resolvers/SubmitActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/SubmitActionResolver.java
@@ -1,0 +1,16 @@
+package pss.www.platform.actions.resolvers;
+
+import pss.core.win.submits.JAct;
+import pss.www.platform.actions.results.JWebActionResult;
+
+public class SubmitActionResolver implements ActionResolverStrategy {
+    @Override
+    public boolean supports(JDoPssActionResolver context, JAct submit) throws Exception {
+        return context.hasToSubmit(submit);
+    }
+
+    @Override
+    public JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable {
+        return context.processSubmit(submit);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ActionResolverStrategy` to encapsulate redirect, link, back and submit logic
- delegate JDoPssActionResolver to specific strategy implementations reducing `instanceof` checks

## Testing
- `javac -d /tmp/out $(find src/pss/www/platform/actions/resolvers -maxdepth 1 -name '*ActionResolver.java') src/pss/www/platform/actions/resolvers/JDoPssActionResolver.java 2>&1 | head -n 20` *(fails: unmappable character for encoding UTF-8)*

------
https://chatgpt.com/codex/tasks/task_e_6896bfc8d9b083338b2f2062a37145f8