### PR TITLE
docs(www): document platform and ui structure

### DIFF
--- a/src/pss/www/README.md
+++ b/src/pss/www/README.md
@@ -47,5 +47,15 @@ JWebActionResult → componentes UI (`JWebView`, `JWebWinForm`, ...)
 - `JWebActionRequestProcessor`: interfaz que inicializa el contexto de aplicación y crea `JWebRequest`.
 - `JWebApplication` / `JWebApplicationSession`: representan la aplicación y la sesión del usuario.
 - `JWebView`, `JWebWinForm` y demás componentes en `ui` construyen la respuesta HTML.
+- `JWebRequestSerializer`: serializa y deserializa el estado de la sesión para mantener `JWebRequest` y ventanas entre peticiones.
+
+## Resolutores clave
+
+| Resolver | Responsabilidad |
+|----------|----------------|
+| `JDoPssActionResolver` | Resolver general de acciones PSS generadas desde la UI. |
+| `JFrontDoorActionResolver` | Punto de entrada para peticiones externas o iniciales. |
+| `JDoLoginResolver` | Manejo del proceso de autenticación. |
+| `JDoAjaxActionResolver` | Atención de solicitudes AJAX parciales. |
 
 Este README resume la finalidad de los subpaquetes y cómo interactúan para servir una solicitud web.


### PR DESCRIPTION
## Summary
- expand README for `pss.www` describing platform vs. ui responsibilities
- list common action resolvers
- mention `JWebRequestSerializer` as the session persistence helper

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896bfd0922c8333b3256bb96bf98ecd