### PR TITLE
fix: avoid StackOverflow in request serialization

### DIFF
--- a/src/pss/www/platform/actions/JWebRequest.java
+++ b/src/pss/www/platform/actions/JWebRequest.java
@@ -48,33 +48,28 @@ public class JWebRequest {
 	private Map<String, String> oRegisteredObjectsOld;
 	private JWebHistoryManager oHistoryManager;
 
-	public class JWebRequestPackage {
-		private Map<String, String> localRegisteredObject;
-		private JLocalHistoryManager localHistoryManager;
 
-//		@Override
-//	  public String toString() {
-//	    try {
-//				return  getRegisterObjectsSerialized();
-//			} catch (Exception e) {
-//				e.printStackTrace();
-//				return "error";
-//			}
-//	  }
 
-		public String getRegisterObjectsSerialized() throws Exception {
-			localRegisteredObject = oRegisteredObjectsNew;
-			localHistoryManager = getHistoryManager().serializeHistoryManager();
-			return JWebRequestSerializer.serializeRegisterJSON(this);
-		}
-	}
+       public static class JWebRequestPackage {
+               private Map<String, String> localRegisteredObject;
+               private JLocalHistoryManager localHistoryManager;
 
-	
-	JWebRequestPackage pack = new JWebRequestPackage();
-	
-	public JWebRequestPackage getPack() {
-		return pack;
-	}
+               public JWebRequestPackage(Map<String, String> localRegisteredObject,
+                               JLocalHistoryManager localHistoryManager) {
+                       this.localRegisteredObject = localRegisteredObject;
+                       this.localHistoryManager = localHistoryManager;
+               }
+
+               public String getRegisterObjectsSerialized() throws Exception {
+                       return JWebRequestSerializer.serializeRegisterJSON(this);
+               }
+       }
+
+
+       public JWebRequestPackage getPack() throws Exception {
+               return new JWebRequestPackage(oRegisteredObjectsNew,
+                               getHistoryManager().serializeHistoryManager());
+       }
 	
 
 


### PR DESCRIPTION
## Summary
- make `JWebRequestPackage` a static class with explicit data, preventing recursive serialization
- build request payload packages on demand with current registered objects and history

## Testing
- `mvn -q test` *(fails: MissingProjectException)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6783cb083339b5f8550b6b7d2c9