### PR TITLE
docs: clarify web request resolver workflow

### DIFF
--- a/src/pss/www/README.md
+++ b/src/pss/www/README.md
@@ -44,6 +44,9 @@ JWebActionResult → componentes UI (`JWebView`, `JWebWinForm`, ...)
 
 - `JWebRequest`: encapsula los datos de la solicitud HTTP, maneja la sesión y coordina el procesamiento.
 - `JDoPssActionResolver`: resuelve y ejecuta acciones de negocio dentro del flujo web.
+- `ActionResolverStrategy` y resolvers concretos (`RedirectActionResolver`, `SubmitActionResolver`, ...):
+  implementan un patrón *strategy* que decide cómo procesar cada `JAct` (redirección,
+  navegación hacia atrás, envío, etc.).
 - `JWebActionRequestProcessor`: interfaz que inicializa el contexto de aplicación y crea `JWebRequest`.
 - `JWebApplication` / `JWebApplicationSession`: representan la aplicación y la sesión del usuario.
 - `JWebView`, `JWebWinForm` y demás componentes en `ui` construyen la respuesta HTML.

--- a/src/pss/www/platform/actions/JWebRequest.java
+++ b/src/pss/www/platform/actions/JWebRequest.java
@@ -46,6 +46,17 @@ import pss.www.ui.controller.JFrontDoorUICoordinator;
 import pss.www.ui.processing.JWebActionRequestProcessor;
 import pss.www.ui.processing.JWebUICoordinator;
 
+/**
+ * Wrapper around the servlet {@link Request} that provides convenient access
+ * to request parameters, session data and registered application objects.
+ * <p>
+ * A {@code JWebRequest} is created by the {@link JWebActionRequestProcessor}
+ * and remains associated with the processing thread through
+ * {@link JWebActionFactory#CURRENT_REQUEST}. It also exposes a
+ * {@link JWebRequestPackage} that captures the state of registered objects and
+ * history information for serialization.
+ * </p>
+ */
 public class JWebRequest {
 
 	private Request oServletRequest;
@@ -59,9 +70,14 @@ public class JWebRequest {
 	private Map<String, String> oRegisteredObjectsOld;
 	private JWebHistoryManager oHistoryManager;
 
-	public class JWebRequestPackage {
-		private Map<String, String> localRegisteredObject;
-		private JLocalHistoryManager localHistoryManager;
+        /**
+         * Lightweight snapshot of the request's registered objects and history
+         * manager. It is primarily used to serialize the server-side state back
+         * to the client when needed.
+         */
+        public class JWebRequestPackage {
+                private Map<String, String> localRegisteredObject;
+                private JLocalHistoryManager localHistoryManager;
 
 //		@Override
 //	  public String toString() {

--- a/src/pss/www/platform/actions/resolvers/ActionResolverStrategy.java
+++ b/src/pss/www/platform/actions/resolvers/ActionResolverStrategy.java
@@ -3,7 +3,20 @@ package pss.www.platform.actions.resolvers;
 import pss.core.win.submits.JAct;
 import pss.www.platform.actions.results.JWebActionResult;
 
+/**
+ * Strategy used by {@link JDoPssActionResolver} to process a particular
+ * {@link JAct}. Each implementation decides whether it supports the action and
+ * how to handle it, returning a {@link JWebActionResult} or delegating back to
+ * the resolver.
+ */
 public interface ActionResolverStrategy {
+    /**
+     * Determines if this strategy can handle the given submit.
+     */
     boolean supports(JDoPssActionResolver context, JAct submit) throws Exception;
+
+    /**
+     * Performs the logic for the given submit when supported.
+     */
     JWebActionResult handle(JDoPssActionResolver context, JAct submit) throws Throwable;
 }

--- a/src/pss/www/platform/actions/resolvers/BackActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/BackActionResolver.java
@@ -4,6 +4,10 @@ import pss.core.win.submits.JAct;
 import pss.core.win.submits.JActBack;
 import pss.www.platform.actions.results.JWebActionResult;
 
+/**
+ * Deals with navigation actions that request to go back in the window history.
+ * It can optionally submit the previous action again depending on context.
+ */
 public class BackActionResolver implements ActionResolverStrategy {
     @Override
     public boolean supports(JDoPssActionResolver context, JAct submit) {

--- a/src/pss/www/platform/actions/resolvers/JDoPssActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/JDoPssActionResolver.java
@@ -51,6 +51,19 @@ import pss.www.platform.applications.JHistory;
 import pss.www.platform.applications.JHistoryProvider;
 import pss.www.platform.users.history.BizUserHistory;
 
+/**
+ * Resolves and executes actions originating from a {@link JWebRequest}.
+ * <p>
+ * The resolver is the core of the request lifecycle: it locates the target
+ * window, determines the {@link BizAction} to execute and delegates the
+ * processing of the underlying {@link JAct} to a chain of
+ * {@link ActionResolverStrategy} implementations. Each strategy decides how to
+ * handle the submit (e.g. redirects, back navigation, regular submits).
+ * </p>
+ * In addition, the resolver manages the registration of objects in the
+ * session, keeps track of modal windows and stores user statistics about the
+ * executed action.
+ */
 public class JDoPssActionResolver extends JIndoorsActionResolver implements IControlToBD {
 
         boolean resetRegisteredObjects=true;

--- a/src/pss/www/platform/actions/resolvers/LinkActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/LinkActionResolver.java
@@ -4,6 +4,10 @@ import pss.core.win.submits.JAct;
 import pss.core.win.submits.JActExternalLink;
 import pss.www.platform.actions.results.JWebActionResult;
 
+/**
+ * Resolves actions that open external links. The resolver delegates to the
+ * context to perform the proper redirection to the target URL.
+ */
 public class LinkActionResolver implements ActionResolverStrategy {
     @Override
     public boolean supports(JDoPssActionResolver context, JAct submit) {

--- a/src/pss/www/platform/actions/resolvers/QueryActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/QueryActionResolver.java
@@ -3,6 +3,11 @@ package pss.www.platform.actions.resolvers;
 import pss.core.win.submits.JAct;
 import pss.www.platform.actions.results.JWebActionResult;
 
+/**
+ * Fallback strategy that simply assigns the target window and continues the
+ * request chain without submitting any data. This is used for read-only
+ * actions such as queries or navigation.
+ */
 public class QueryActionResolver implements ActionResolverStrategy {
     @Override
     public boolean supports(JDoPssActionResolver context, JAct submit) {

--- a/src/pss/www/platform/actions/resolvers/RedirectActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/RedirectActionResolver.java
@@ -4,6 +4,10 @@ import pss.core.win.submits.JAct;
 import pss.core.win.submits.JActFileGenerate;
 import pss.www.platform.actions.results.JWebActionResult;
 
+/**
+ * Handles {@link JAct} instances that generate files, producing a redirect
+ * response so the file can be downloaded by the client.
+ */
 public class RedirectActionResolver implements ActionResolverStrategy {
     @Override
     public boolean supports(JDoPssActionResolver context, JAct submit) throws Exception {

--- a/src/pss/www/platform/actions/resolvers/SubmitActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/SubmitActionResolver.java
@@ -3,6 +3,10 @@ package pss.www.platform.actions.resolvers;
 import pss.core.win.submits.JAct;
 import pss.www.platform.actions.results.JWebActionResult;
 
+/**
+ * Resolves generic submit actions. When the context indicates that the submit
+ * should be performed, the resolver invokes {@link JDoPssActionResolver#processSubmit(JAct)}.
+ */
 public class SubmitActionResolver implements ActionResolverStrategy {
     @Override
     public boolean supports(JDoPssActionResolver context, JAct submit) throws Exception {


### PR DESCRIPTION
## Summary
- Document how `JDoPssActionResolver` orchestrates action execution
- Add JavaDoc for `JWebRequest` and the resolver strategy classes
- Expand README with strategy pattern overview

## Testing
- `javac -cp src src/pss/www/platform/actions/resolvers/JDoPssActionResolver.java src/pss/www/platform/actions/resolvers/ActionResolverStrategy.java src/pss/www/platform/actions/resolvers/RedirectActionResolver.java src/pss/www/platform/actions/resolvers/LinkActionResolver.java src/pss/www/platform/actions/resolvers/BackActionResolver.java src/pss/www/platform/actions/resolvers/SubmitActionResolver.java src/pss/www/platform/actions/resolvers/QueryActionResolver.java src/pss/www/platform/actions/JWebRequest.java` *(fails: unmappable character for encoding UTF-8)*

------
https://chatgpt.com/codex/tasks/task_e_689758d6d53083339a9cc54b41ff21d2