### PR TITLE
docs: document BizAction and JAct classes

### DIFF
--- a/src/pss/core/win/actions/BizAction.java
+++ b/src/pss/core/win/actions/BizAction.java
@@ -25,6 +25,15 @@ import pss.core.winUI.forms.JBaseForm;
 import pss.core.winUI.icons.GuiIconos;
 import pss.www.platform.actions.JWebActionFactory;
 
+/**
+ * Represents a configurable action within a window.
+ * <p>
+ * Each {@code BizAction} defines the behavior executed from the UI, the
+ * security restrictions that apply and the visual aspects used when rendering
+ * the action. Instances are usually attached to {@link pss.core.win.JBaseWin}
+ * components and can in turn own child actions forming a hierarchy.
+ * </p>
+ */
 public class BizAction extends JRecord {
 
 	private JBaseWin owner = null;
@@ -180,7 +189,7 @@ public class BizAction extends JRecord {
 	protected boolean uploaddata=false;
 	protected boolean isSubmitedByUser=false;
 
-	// Esto sólo se utiliza en casos muy puntuales y se inicializa on demand
+	// Esto sÃ³lo se utiliza en casos muy puntuales y se inicializa on demand
 	// private JList oFiltros = null;
 	// public void addFiltro( RFilter zFiltro ) {
 	// if( oFiltros == null ) oFiltros = JCollectionFactory.createList();
@@ -570,8 +579,8 @@ public class BizAction extends JRecord {
 
 	@Override
 	public void createFixedProperties() throws Exception {
-		this.addFixedItem(KEY, "accion", "Operación", true, true, 20);
-		this.addFixedItem(FIELD, "descripcion", "Descripción", true, true, 50);
+		this.addFixedItem(KEY, "accion", "OperaciÃ³n", true, true, 20);
+		this.addFixedItem(FIELD, "descripcion", "DescripciÃ³n", true, true, 50);
 		this.addFixedItem(FIELD, "nro_icono", "Nro Icono", true, true, 3);
 		this.addFixedItem(VIRTUAL, "restringido", "Restringido", true, true, 1);
 	}

--- a/src/pss/core/win/actions/BizActions.java
+++ b/src/pss/core/win/actions/BizActions.java
@@ -4,6 +4,13 @@ import pss.core.services.records.JRecords;
 import pss.core.tools.JTools;
 import pss.core.tools.collections.JIterator;
 
+/**
+ * Collection of {@link BizAction} objects used by a window.
+ * <p>
+ * Provides helper methods for searching actions by identifier or unique name
+ * and for cloning the whole set of actions when required by the UI layer.
+ * </p>
+ */
 public class BizActions extends JRecords<BizAction> {
 
 	public BizActions() throws Exception {

--- a/src/pss/core/win/submits/JAct.java
+++ b/src/pss/core/win/submits/JAct.java
@@ -19,10 +19,13 @@ import pss.core.win.actions.BizAction;
 import pss.core.winUI.forms.JBaseForm;
 
 /**
- * 
- * <b>JAct</b>
- * <p>Representación de una accion</p>
- * <p>Contiene el Win al que se le aplica la accion (owner), la accion a aplicar (actionId) y el Win resultante (result)</p>
+ * Base class for all executable actions in the UI framework.
+ * <p>
+ * A {@code JAct} ties together the originating window, the identifier of the
+ * action to perform and the resulting window or form. Subclasses implement the
+ * specific behavior (query, modification, navigation, etc.) that should happen
+ * when the action is triggered.
+ * </p>
  */
 public abstract class JAct implements Cloneable, Serializable {
 
@@ -452,7 +455,7 @@ public abstract class JAct implements Cloneable, Serializable {
 				
   protected JAct getSubmitById() throws Exception {
   	BizAction a = this.getWinResult().findActionByUniqueId(this.getActionUniqueId(), false, false); // fuerzo el ok action
-  	if (a==null) JExcepcion.SendError("No Existe acción: " + this.getActionUniqueId());
+  	if (a==null) JExcepcion.SendError("No Existe acciÃ³n: " + this.getActionUniqueId());
   	a.setModal(getActionSource().isModal());
   	return a.getSubmit();
 	}

--- a/src/pss/core/win/submits/JActDelete.java
+++ b/src/pss/core/win/submits/JActDelete.java
@@ -2,6 +2,13 @@ package pss.core.win.submits;
 
 import pss.core.win.JBaseWin;
 
+/**
+ * Action that removes the current record from the data source.
+ * <p>
+ * The action is marked as a submit-only operation and it will update the
+ * navigation flow after the deletion is performed.
+ * </p>
+ */
 public class JActDelete extends JAct {
 
 /**
@@ -18,8 +25,8 @@ public class JActDelete extends JAct {
 
 	@Override
 	public void Do() throws Exception {
-//		if (!UITools.showConfirmation("Confirmación",
-//				"¿Está seguro que desea borrar el registro?"))
+//		if (!UITools.showConfirmation("ConfirmaciÃ³n",
+//				"Â¿EstÃ¡ seguro que desea borrar el registro?"))
 //			return;
 		this.submit();
 	}

--- a/src/pss/core/win/submits/JActModify.java
+++ b/src/pss/core/win/submits/JActModify.java
@@ -4,6 +4,14 @@ import pss.core.tools.JExceptionOnlyMessage;
 import pss.core.win.JBaseWin;
 import pss.core.winUI.forms.JBaseForm;
 
+/**
+ * Base class for actions that modify the underlying record.
+ * <p>
+ * Provides helper methods to obtain either a new form or an update form and to
+ * notify controls about changes triggered by the user. Concrete subclasses
+ * implement the specific behaviour for insert, update or delete operations.
+ * </p>
+ */
 public abstract class JActModify extends JAct {
 
 

--- a/src/pss/core/win/submits/JActNew.java
+++ b/src/pss/core/win/submits/JActNew.java
@@ -3,6 +3,14 @@ package pss.core.win.submits;
 import pss.core.win.JBaseWin;
 import pss.core.winUI.forms.JBaseForm;
 
+/**
+ * Action responsible for inserting a new record.
+ * <p>
+ * Depending on the state of the backing record it can display either a new
+ * form or, if the record already exists, an update form. The behaviour can be
+ * customised through several constructor flags.
+ * </p>
+ */
 public class JActNew extends JActModify {
 
 	/**

--- a/src/pss/core/win/submits/JActQuery.java
+++ b/src/pss/core/win/submits/JActQuery.java
@@ -4,6 +4,13 @@ import pss.core.tools.PssLogger;
 import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
 
+/**
+ * Action used to display the data of a record without modifying it.
+ * <p>
+ * Generates a read-only form from the target window and marks the action as
+ * part of the navigation history so the user can return to previous screens.
+ * </p>
+ */
 public class JActQuery extends JAct {
 
 	public JActQuery(JWin zResult) {

--- a/src/pss/core/win/submits/JActSubmit.java
+++ b/src/pss/core/win/submits/JActSubmit.java
@@ -2,6 +2,14 @@ package pss.core.win.submits;
 
 import pss.core.win.JBaseWin;
 
+/**
+ * Basic action that simply submits the current window without opening any
+ * additional UI.
+ * <p>
+ * It is commonly used for operations that only execute server side logic and
+ * then return to the same context.
+ * </p>
+ */
 public class JActSubmit extends JAct {
 		
 	/**
@@ -22,7 +30,7 @@ public class JActSubmit extends JAct {
 ////		JAct submit = this;
 //		if (this.hasActionId()) {
 //			BizAction action = this.getResult().findAction(this.getActionId());
-//			if (action.hasConfirmMessage() &&	!UITools.showConfirmation("Confirmación", action.getConfirmMessageDescription()))
+//			if (action.hasConfirmMessage() &&	!UITools.showConfirmation("ConfirmaciÃ³n", action.getConfirmMessageDescription()))
 //				return;
 ////			submit = action.getSubmit();
 //		}

--- a/src/pss/core/win/submits/JActUpdate.java
+++ b/src/pss/core/win/submits/JActUpdate.java
@@ -5,6 +5,13 @@ import pss.core.win.JBaseWin;
 import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
 
+/**
+ * Action that updates an existing record.
+ * <p>
+ * It generates an update form for the target window and performs the
+ * persistence logic when submitted.
+ * </p>
+ */
 public class JActUpdate extends JActModify {
 	
 //	private JBaseForm form;

--- a/src/pss/core/win/submits/JActWins.java
+++ b/src/pss/core/win/submits/JActWins.java
@@ -5,7 +5,14 @@ import pss.core.win.JBaseWin;
 import pss.core.win.JControlWin;
 import pss.core.win.JWins;
 
-
+/**
+ * Action that opens a list of records inside a {@link JWins} container.
+ * <p>
+ * It supports multi selection as well as single line selection depending on
+ * the configuration passed to the constructor. The resulting window can be used
+ * to select elements or simply browse information.
+ * </p>
+ */
 public class JActWins extends JAct {
 	
 	private boolean bMultiple=true;


### PR DESCRIPTION
## Summary
- add class-level documentation for BizAction and BizActions
- document JAct and related submit classes to clarify their responsibilities

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `gradle test` *(fails: Directory '/workspace/gsCrono' does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68975f26d3ec83339ca8628d481fcd82