### PR TITLE
Optimize JBaseWin session serialization

### DIFF
--- a/src/pss/www/platform/actions/JWebWinFactory.java
+++ b/src/pss/www/platform/actions/JWebWinFactory.java
@@ -899,13 +899,21 @@ public class JWebWinFactory {
 		return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
 	}
 
-	public String baseRecToJSON(JBaseRecord rec) throws Exception {
-		JSerializableBaseWin serializableWin = prepareSerializableRec(rec, false);
-		String json = objectMapper.writeValueAsString(serializableWin);
+        public String baseRecToJSON(JBaseRecord rec) throws Exception {
+                JSerializableBaseWin serializableWin = prepareSerializableRec(rec, false);
+                String json = objectMapper.writeValueAsString(serializableWin);
 
-		// Codificar en Base64
-		return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
-	}
+                // Codificar en Base64
+                return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        }
+
+        public JBaseWin jsonToBaseWin(String json) throws Exception {
+                return createWin(json, null);
+        }
+
+        public JBaseRecord jsonToBaseRec(String json) throws Exception {
+                return createRec(json, null);
+        }
 
 	// Método para deserializar desde JSON (como JAct u otros objetos)
 	public Object deserializeObject(String json, Class<?> clazz) throws IOException {


### PR DESCRIPTION
## Summary
- Compress window and record session payloads using deflate and URL-safe Base64
- Decode `obj_t_` and `obj_rec_` payloads without Java serialization
- Provide JSON reconstruction helpers in `JWebWinFactory`

## Testing
- `javac -cp src src/pss/www/platform/actions/JWebRequest.java src/pss/www/platform/actions/JWebWinFactory.java` *(fails: package org.apache.cocoon.environment does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6897b254aac88333b37c25a4d29c215c