### PR TITLE
feat: reuse registered object dictionary with reconciliation

### DIFF
--- a/src/pss/www/platform/actions/JWebWinFactory.java
+++ b/src/pss/www/platform/actions/JWebWinFactory.java
@@ -994,9 +994,16 @@ public class JWebWinFactory {
 			return;
 		JRecords recs = (JRecords<JRecord>) actionOwner;
 		recs.setStatic(true);
-		for (String element : serializableWin.elements) {
-			recs.getStaticItems().addElement(getRegisterObjectRecTemp(element.substring(8)));
-		}
+                for (String element : serializableWin.elements) {
+                        if (element.startsWith("obj_rec_")) {
+                                recs.getStaticItems().addElement(getRegisterObjectRecTemp(element.substring(8)));
+                        } else {
+                                Serializable obj = JWebActionFactory.getCurrentRequest().getRegisterObject(element);
+                                if (obj instanceof JBaseRecord) {
+                                        recs.getStaticItems().addElement((JBaseRecord) obj);
+                                }
+                        }
+                }
 
 	}
 
@@ -1012,15 +1019,23 @@ public class JWebWinFactory {
 			String fieldKey = entry.getKey();
 			String propValue = entry.getValue();
 
-			if (fieldKey.startsWith("REC_")) {
-				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
-				obj.setValue(getRegisterObjectRecTemp(propValue.substring(8)));
-			} else if (fieldKey.startsWith("RECS_")) {
-				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(5));
-				obj.setValue(getRegisterObjectRecTemp(propValue.substring(8)));
-			} else if (fieldKey.startsWith("UID_")) {
-				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
-				obj.setUniqueId(propValue);
+                        if (fieldKey.startsWith("REC_")) {
+                                JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
+                                if (propValue.startsWith("obj_rec_")) {
+                                        obj.setValue(getRegisterObjectRecTemp(propValue.substring(8)));
+                                } else {
+                                        obj.setValue((JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue));
+                                }
+                        } else if (fieldKey.startsWith("RECS_")) {
+                                JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(5));
+                                if (propValue.startsWith("obj_rec_")) {
+                                        obj.setValue(getRegisterObjectRecTemp(propValue.substring(8)));
+                                } else {
+                                        obj.setValue((JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue));
+                                }
+                        } else if (fieldKey.startsWith("UID_")) {
+                                JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
+                                obj.setUniqueId(propValue);
 			} else if (fieldKey.startsWith("PROP_")) {
 				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(5));
 				obj.setValueFormUI(propValue);
@@ -1034,20 +1049,29 @@ public class JWebWinFactory {
 				} catch (NoSuchFieldException | IllegalAccessException e) {
 					System.err.println("Error al asignar campo OTH: " + fieldName + " -> " + e.getMessage());
 				}
-			} else if (fieldKey.startsWith("SREC_")) {
-				Field field = currentClass.getDeclaredField(fieldKey.substring(5));
-				field.setAccessible(true);
-
-				JBaseRecord obj = getRegisterObjectRecTemp(propValue.substring(8));
-				field.set(actionOwner, obj); 
-			} else if (fieldKey.startsWith("SRECS_")) {
-				Field field = currentClass.getDeclaredField(fieldKey.substring(6));
-				field.setAccessible(true);
-				JBaseRecord obj = getRegisterObjectRecTemp(propValue.substring(8));
-				field.set(actionOwner, obj); 
-			} else if (fieldKey.startsWith("SER_")) {
-				String fieldName = fieldKey.substring(4);
-				try {
+                        } else if (fieldKey.startsWith("SREC_")) {
+                                Field field = currentClass.getDeclaredField(fieldKey.substring(5));
+                                field.setAccessible(true);
+                                JBaseRecord obj;
+                                if (propValue.startsWith("obj_rec_")) {
+                                        obj = getRegisterObjectRecTemp(propValue.substring(8));
+                                } else {
+                                        obj = (JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue);
+                                }
+                                field.set(actionOwner, obj);
+                        } else if (fieldKey.startsWith("SRECS_")) {
+                                Field field = currentClass.getDeclaredField(fieldKey.substring(6));
+                                field.setAccessible(true);
+                                JBaseRecord obj;
+                                if (propValue.startsWith("obj_rec_")) {
+                                        obj = getRegisterObjectRecTemp(propValue.substring(8));
+                                } else {
+                                        obj = (JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue);
+                                }
+                                field.set(actionOwner, obj);
+                        } else if (fieldKey.startsWith("SER_")) {
+                                String fieldName = fieldKey.substring(4);
+                                try {
 					Field field = currentClass.getDeclaredField(fieldName);
 					field.setAccessible(true);
 


### PR DESCRIPTION
## Summary
- avoid re-serializing already registered windows/records by reusing previous payloads
- add reconciliation with keep/evict support and optional handle invalidation
- support hold list parsing and update win factory to consume dictionary keys

## Testing
- `javac -cp src src/pss/www/platform/actions/JWebRequest.java src/pss/www/platform/actions/JWebWinFactory.java >/tmp/compile.log && tail -n 20 /tmp/compile.log`


------
https://chatgpt.com/codex/tasks/task_e_6897bf96d7fc83339c75a4054751296a