### PR TITLE
Add Caffeine caching for pack serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>pss</groupId>
+  <artifactId>gsCrono</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.9.3</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/pss/www/platform/cache/PackCaches.java
+++ b/src/pss/www/platform/cache/PackCaches.java
@@ -1,0 +1,30 @@
+package pss.www.platform.cache;
+
+import com.github.benmanes.caffeine.cache.*;
+import java.util.concurrent.TimeUnit;
+
+public final class PackCaches {
+  private PackCaches() {}
+
+  // Cachea el pack (b64url(deflate(JSON))) por uniqueId y "sello" (ver abajo).
+  public static final Cache<String, String> WIN_PACK = Caffeine.newBuilder()
+      .maximumWeight(64L * 1024 * 1024) // 64MB de packs
+      .weigher(new Weigher<String,String>() {
+        @Override public int weigh(String k, String v) { return v != null ? v.length() : 0; }
+      })
+      .expireAfterAccess(10, TimeUnit.MINUTES)
+      .recordStats()
+      .build();
+
+  public static final Cache<String, String> REC_PACK = Caffeine.newBuilder()
+      .maximumWeight(64L * 1024 * 1024)
+      .weigher(new Weigher<String,String>() {
+        @Override public int weigh(String k, String v) { return v != null ? v.length() : 0; }
+      })
+      .expireAfterAccess(10, TimeUnit.MINUTES)
+      .recordStats()
+      .build();
+
+  public static void invalidateWinKey(String key) { WIN_PACK.invalidate(key); }
+  public static void invalidateRecKey(String key) { REC_PACK.invalidate(key); }
+}


### PR DESCRIPTION
## Summary
- Add Caffeine dependency and Java 8 compiler settings
- Cache packed window and record representations via new PackCaches
- Memoize pack generation in JWebWinFactory with invalidation helpers

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not resolve plugin maven-resources-plugin due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897fdc3ee108333ace0f10c46b4251e