### PR TITLE
Fix double packaging after baseWin/baseRec serialization change

### DIFF
--- a/src/pss/www/platform/actions/JWebRequest.java
+++ b/src/pss/www/platform/actions/JWebRequest.java
@@ -801,13 +801,13 @@ public class JWebRequest {
 			getRegisteredObjectsNew().put(id, CACHE_PREFIX + id);
 			return CACHE_PREFIX + id;
 		}
-		if (objectsCreated.containsKey(zObject.getUniqueId()))
-			return objectsCreated.get(zObject.getUniqueId());
-		String json = new JWebWinFactory(null).baseWinToJSON(zObject);
-		String out = "obj_t_" + b64url(deflate(JTools.stringToByteArray(json)));
-		objectsCreated.put(zObject.getUniqueId(), out);
-		return out;
-	}
+               if (objectsCreated.containsKey(zObject.getUniqueId()))
+                       return objectsCreated.get(zObject.getUniqueId());
+               String packed = new JWebWinFactory(null).baseWinToJSON(zObject);
+               String out = "obj_t_" + packed;
+               objectsCreated.put(zObject.getUniqueId(), out);
+               return out;
+        }
 
 	public synchronized String registerRecObjectObj(JBaseRecord zObject) throws Exception {
 		if (zObject == null)
@@ -820,11 +820,11 @@ public class JWebRequest {
 			getRegisteredObjectsNew().put(key, CACHE_PREFIX + key);
 			return key;
 		}
-		String json = new JWebWinFactory(null).baseRecToJSON(zObject);
-		String payload = "obj_rec_" + b64url(deflate(JTools.stringToByteArray(json)));
-		getRegisteredObjectsNew().put(key, payload);
-		return key;
-	}
+               String packed = new JWebWinFactory(null).baseRecToJSON(zObject);
+               String payload = "obj_rec_" + packed;
+               getRegisteredObjectsNew().put(key, payload);
+               return key;
+        }
 
 	public Serializable getRegisterObject(String key) {
 		String obj = getRegisteredObjectsOld().get(key);
@@ -842,22 +842,22 @@ public class JWebRequest {
 			if (obj.startsWith("obj_rec:")) {
 				return (Serializable) fetchFromCache(obj.substring(8));
 			}
-			if (obj.startsWith("obj_t_")) {
-				String payload = obj.substring(6);
-				byte[] raw = inflate(b64urlDecode(payload));
-				String json = JTools.byteVectorToString(raw);
-				return new JWebWinFactory(null).jsonToBaseWin(json);
-			}
-			if (obj.startsWith("obj_rec_")) {
-				String payload = obj.substring(8);
-				byte[] raw = inflate(b64urlDecode(payload));
-				String json = JTools.byteVectorToString(raw);
-				return new JWebWinFactory(null).jsonToBaseRec(json);
-			}
-			return deserializeObject(obj);
-		} catch (Exception e) {
-			PssLogger.logError(e);
-			return null;
+                       if (obj.startsWith("obj_t_")) {
+                               String payload = obj.substring(6);
+                               byte[] raw = inflate(Base64.getDecoder().decode(payload));
+                               String json = JTools.byteVectorToString(raw);
+                               return new JWebWinFactory(null).jsonToBaseWin(json);
+                       }
+                       if (obj.startsWith("obj_rec_")) {
+                               String payload = obj.substring(8);
+                               byte[] raw = inflate(Base64.getDecoder().decode(payload));
+                               String json = JTools.byteVectorToString(raw);
+                               return new JWebWinFactory(null).jsonToBaseRec(json);
+                       }
+                       return deserializeObject(obj);
+               } catch (Exception e) {
+                       PssLogger.logError(e);
+                       return null;
 		}
 	}
 
@@ -1113,10 +1113,8 @@ public class JWebRequest {
 //		if (zOwner.isModeWinLov()) return serializeObject(zOwner);
 //		if (!zOwner.isReaded()) return serializeObject(zOwner);
 
-		String json = new JWebWinFactory(null).baseWinToJSON(zOwner);
-		byte[] raw = JTools.stringToByteArray(json);
-		String packed = b64url(deflate(raw));
-		return "obj_t_" + packed;
-	}
+               String packed = new JWebWinFactory(null).baseWinToJSON(zOwner);
+               return "obj_t_" + packed;
+        }
 
 }

--- a/src/pss/www/platform/actions/JWebWinFactory.java
+++ b/src/pss/www/platform/actions/JWebWinFactory.java
@@ -652,35 +652,45 @@ public class JWebWinFactory {
 		}
 	}
 
-	public JBaseWin getRegisterObjectTemp(String zKey) throws Exception {
-		try {
-			return createWinFromPack(zKey, null);
-		} catch (Exception e) {
-			byte[] decoded;
-			try {
-				decoded = java.util.Base64.getUrlDecoder().decode(zKey);
-			} catch (IllegalArgumentException ex) {
-				decoded = java.util.Base64.getDecoder().decode(zKey);
-			}
-			String json = JTools.byteVectorToString(decoded);
-			return createWinFromJson(json, null);
-		}
-	}
+        public JBaseWin getRegisterObjectTemp(String zKey) throws Exception {
+                try {
+                        return createWinFromPack(zKey, null);
+                } catch (Exception e) {
+                       byte[] decoded;
+                       try {
+                               decoded = java.util.Base64.getUrlDecoder().decode(zKey);
+                       } catch (IllegalArgumentException ex) {
+                               decoded = java.util.Base64.getDecoder().decode(zKey);
+                       }
+                       String json;
+                       try {
+                               json = new String(decompress(decoded), StandardCharsets.UTF_8);
+                       } catch (Exception ex2) {
+                               json = JTools.byteVectorToString(decoded);
+                       }
+                       return createWinFromJson(json, null);
+                }
+        }
 
-	public JBaseRecord getRegisterObjectRecTemp(String zKey) throws Exception {
-		try {
-			return createRecFromPack(zKey, null);
-		} catch (Exception e) {
-			byte[] decoded;
-			try {
-				decoded = java.util.Base64.getUrlDecoder().decode(zKey);
-			} catch (IllegalArgumentException ex) {
-				decoded = java.util.Base64.getDecoder().decode(zKey);
-			}
-			String json = JTools.byteVectorToString(decoded);
-			return createRecFromJson(json, null);
-		}
-	}
+        public JBaseRecord getRegisterObjectRecTemp(String zKey) throws Exception {
+                try {
+                        return createRecFromPack(zKey, null);
+                } catch (Exception e) {
+                       byte[] decoded;
+                       try {
+                               decoded = java.util.Base64.getUrlDecoder().decode(zKey);
+                       } catch (IllegalArgumentException ex) {
+                               decoded = java.util.Base64.getDecoder().decode(zKey);
+                       }
+                       String json;
+                       try {
+                               json = new String(decompress(decoded), StandardCharsets.UTF_8);
+                       } catch (Exception ex2) {
+                               json = JTools.byteVectorToString(decoded);
+                       }
+                       return createRecFromJson(json, null);
+                }
+        }
 
 	private boolean isExport() throws Exception {
 		JWebActionData p = JWebActionFactory.getCurrentRequest().getData("export");

--- a/src/pss/www/platform/applications/JHistoryProvider.java
+++ b/src/pss/www/platform/applications/JHistoryProvider.java
@@ -2,13 +2,11 @@ package pss.www.platform.applications;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
 import pss.core.services.records.JFilterMap;
 import pss.core.tools.JPair;
-import pss.core.tools.JTools;
 import pss.core.tools.collections.JCollectionFactory;
 import pss.core.tools.collections.JIterator;
 import pss.core.tools.collections.JMap;
@@ -69,13 +67,13 @@ public class JHistoryProvider implements Serializable {
 		
 		if (multipleSelect != null) {
 			multiSelectName = zMultipleSelect.getClass().getCanonicalName();
-			JIterator<JWin> it = zMultipleSelect.getStaticIterator();
-			while(it.hasMoreElements()) {
-				JWin win = it.nextElement();
-				multipleSelect.add(Base64.getEncoder().encodeToString(JTools.stringToByteArray(new JWebWinFactory(null).baseWinToJSON(win))));
-			}
-		}
-	}
+                       JIterator<JWin> it = zMultipleSelect.getStaticIterator();
+                       while(it.hasMoreElements()) {
+                               JWin win = it.nextElement();
+                               multipleSelect.add(new JWebWinFactory(null).baseWinToJSON(win));
+                       }
+               }
+       }
 
 	public JHistoryProvider() {
 	}


### PR DESCRIPTION
## Summary
- use baseWinToJSON/baseRecToJSON output directly when registering objects
- decompress base64-encoded payloads when retrieving temporary win/rec objects
- stop re-encoding wins in history provider multiple select

## Testing
- `mvn -q -e test` *(fails: The goal you specified requires a project to execute but there is no POM)*

------
https://chatgpt.com/codex/tasks/task_e_68989e0927ac8333901c94b580a9268b